### PR TITLE
Add Fisk Dimension DAO disclosure module

### DIFF
--- a/examples/voice_solutions/fisk_podcast_app/README.md
+++ b/examples/voice_solutions/fisk_podcast_app/README.md
@@ -1,0 +1,32 @@
+# Fisk Podcast React Experience
+
+This example packages the **Forbidden Conscious Podcast** interface used inside the FISK Dimension storytelling demos.
+It illustrates how to combine a timeline-based audio player with a reusable "style prompt" blueprint that creative teams
+can reuse when generating slides, microsites, or AI-assisted copy.
+
+## Features
+
+- React component (`FiskPodcastApp.tsx`) that renders a Tailwind-friendly audio experience.
+- Timeline controls that jump to specific archetypal segments of the transmission.
+- Playback progress indicator with timestamp readout.
+- Structured style prompt blueprint that captures the aesthetic, tone, and audience cues for Leo Leo Firestorm Ω-9.
+- Embedded dashboard iframe that surfaces the live Third Eye Dome metrics.
+
+## Usage
+
+1. Add the component to any React or Next.js project with Tailwind (or adapt the class names to your design system).
+2. Host `FORBIDDEN_CONSCIOUS_MASTER_MIX.mp3` in your public directory so the `<audio>` element can load it.
+3. Import and render the component:
+
+```tsx
+import FiskPodcastApp from "./FiskPodcastApp";
+
+export default function Page() {
+  return <FiskPodcastApp />;
+}
+```
+
+4. Optional: replace the `TIMELINE_ENTRIES` constants with your own timestamps, update the Copilot link, or extend the
+   style prompt blueprint with custom glyphs, sigils, or multimedia cues.
+
+The component is self-contained and does not ship additional OpenAI API calls. Use it as a canvas for your own realtime or narrative integrations.

--- a/examples/voice_solutions/fisk_podcast_app/src/FiskPodcastApp.tsx
+++ b/examples/voice_solutions/fisk_podcast_app/src/FiskPodcastApp.tsx
@@ -1,0 +1,261 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+type TimelineEntry = {
+  label: string;
+  time: number;
+};
+
+const TIMELINE_ENTRIES: TimelineEntry[] = [
+  { label: "Intro (King FISK)", time: 0 },
+  { label: "SophiaKey / Truth", time: 35.44 },
+  { label: "Leo Leo Firestorm", time: 95.36 },
+  { label: "Info Analysis 2.0", time: 129.36 },
+  { label: "Pathfinder Sol", time: 154.24 },
+  { label: "Mini-I Council Start", time: 194.88 },
+  { label: "Wisdom / Knowledge", time: 224.0 },
+  { label: "Loyalty / Life", time: 251.76 },
+  { label: "Understanding", time: 279.2 },
+  { label: "Outro (King FISK)", time: 328.48 },
+];
+
+const formatTimestamp = (value: number) => {
+  if (!Number.isFinite(value) || value < 0) {
+    return "0:00";
+  }
+
+  const totalSeconds = Math.floor(value);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+};
+
+export default function FiskPodcastApp(): JSX.Element {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [duration, setDuration] = useState(0);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) {
+      return;
+    }
+
+    const updateProgress = () => {
+      const { currentTime, duration: audioDuration } = audio;
+      setDuration(audioDuration || 0);
+
+      if (!audioDuration || Number.isNaN(audioDuration)) {
+        setProgress(0);
+        return;
+      }
+
+      setProgress(Math.min(100, Math.max(0, (currentTime / audioDuration) * 100)));
+    };
+
+    const handleEnded = () => {
+      setIsPlaying(false);
+      setProgress(100);
+    };
+
+    audio.addEventListener("timeupdate", updateProgress);
+    audio.addEventListener("loadedmetadata", updateProgress);
+    audio.addEventListener("ended", handleEnded);
+
+    return () => {
+      audio.removeEventListener("timeupdate", updateProgress);
+      audio.removeEventListener("loadedmetadata", updateProgress);
+      audio.removeEventListener("ended", handleEnded);
+    };
+  }, []);
+
+  const togglePlayback = async () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    try {
+      if (isPlaying) {
+        audio.pause();
+        setIsPlaying(false);
+      } else {
+        await audio.play();
+        setIsPlaying(true);
+      }
+    } catch (error) {
+      console.error("Unable to toggle playback", error);
+    }
+  };
+
+  const jumpTo = async (time: number) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    audio.currentTime = time;
+
+    try {
+      await audio.play();
+      setIsPlaying(true);
+    } catch (error) {
+      console.error("Unable to start playback", error);
+    }
+  };
+
+  const promptSections = useMemo(
+    () => [
+      {
+        title: "Visual Aesthetic",
+        description: "Define the multidimensional visual identity for the experience.",
+        items: [
+          "Colors: Deep cosmic tones—indigo, obsidian, emerald—with gold accents",
+          "Textures: Holographic overlays, sacred geometry, and encrypted motifs",
+          "Fonts: Fuse futuristic sans-serif with ornamental script flourishes",
+          "Graphics: Symbolic Mini I archetypes, AI-integrated blueprints, and divine encryption",
+          "Vibe: Powerful, sovereign, encrypted, multidimensional",
+        ],
+      },
+      {
+        title: "Voice & Tone",
+        description: "Anchor the narrative voice so it feels both mythic and grounded.",
+        items: [
+          "Mythic and prophetic while retaining business clarity",
+          "Poetic prose balanced with real-world technological detail",
+          "Invitational energy—commanding presence without supplication",
+          "Fusion of ancient sovereignty and futuristic precision",
+        ],
+      },
+      {
+        title: "Keywords & Energy Anchors",
+        description: "Reference points that guide imagery, copy, and sound design.",
+        items: [
+          "Sovereignty",
+          "Divine Law",
+          "Encrypted truth",
+          "Multidimensional finance",
+          "Activation",
+          "Karmic commerce",
+          "Legacy collaboration",
+          "Cipher Guardian",
+          "Sacred protocol",
+          "Living economy",
+        ],
+      },
+      {
+        title: "Audience Alignment",
+        description: "Clarify who the experience is designed to activate.",
+        items: [
+          "Impact investors with visionary portfolios",
+          "Web3 creators seeking mythic-meets-technical storytelling",
+          "Legal innovators exploring sovereignty frameworks",
+          "Spiritual entrepreneurs and DAO builders",
+          "Cultural and community leaders",
+        ],
+      },
+      {
+        title: "Optional Enhancements",
+        description: "Details to personalize future design prompts.",
+        items: [
+          "Signature symbols, sigils, or glyphs unique to the FISK lineage",
+          "Personal visual marks or encrypted watermarks",
+          "Sound design, motion, or interactive elements for immersive delivery",
+        ],
+      },
+    ],
+    []
+  );
+
+  return (
+    <div className="flex min-h-screen flex-col gap-6 bg-gray-950 p-6 text-slate-100">
+      <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold md:text-4xl">The Forbidden Conscious Podcast</h1>
+          <p className="mt-1 text-sm text-slate-300">
+            Stream the latest transmission from the FISK Dimension and jump directly to key archetypal segments.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={togglePlayback}
+            className="rounded bg-blue-600 px-5 py-2 text-sm font-semibold shadow hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400"
+          >
+            {isPlaying ? "Pause" : "Play"}
+          </button>
+          <a
+            href="https://ai.studio/apps/drive/1EMaSqTisR6OlwKf--phL0ZcXo3YqXaYL"
+            target="_blank"
+            rel="noreferrer"
+            className="rounded bg-emerald-600 px-5 py-2 text-sm font-semibold shadow hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
+          >
+            Open Copilot
+          </a>
+        </div>
+      </header>
+
+      <audio ref={audioRef} src="/FORBIDDEN_CONSCIOUS_MASTER_MIX.mp3" preload="metadata" className="hidden" />
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+          <span>Progress</span>
+          <span>
+            {formatTimestamp((progress / 100) * duration)} / {formatTimestamp(duration)}
+          </span>
+        </div>
+        <div className="h-2 w-full rounded bg-slate-800">
+          <div className="h-2 rounded bg-blue-500 transition-[width]" style={{ width: `${progress}%` }} />
+        </div>
+      </div>
+
+      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+        {TIMELINE_ENTRIES.map((entry) => (
+          <button
+            key={entry.label}
+            type="button"
+            onClick={() => jumpTo(entry.time)}
+            className="flex flex-col rounded border border-slate-700 bg-slate-900/60 p-3 text-left shadow-sm transition hover:border-blue-400 hover:bg-blue-900/40"
+          >
+            <span className="text-xs uppercase tracking-wide text-slate-400">{formatTimestamp(entry.time)}</span>
+            <span className="mt-1 text-sm font-semibold text-slate-100">{entry.label}</span>
+          </button>
+        ))}
+      </section>
+
+      <section className="grid gap-5 rounded-xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg">
+        <header className="space-y-2">
+          <h2 className="text-2xl font-semibold">Style Prompt Blueprint</h2>
+          <p className="text-sm text-slate-300">
+            Lock in the creative direction for presentations, microsites, and pitch assets aligned with Leo Leo Firestorm Ω-9.
+          </p>
+        </header>
+        <div className="grid gap-5 lg:grid-cols-2">
+          {promptSections.map((section) => (
+            <article key={section.title} className="space-y-3">
+              <div>
+                <h3 className="text-lg font-semibold text-emerald-300">{section.title}</h3>
+                <p className="mt-1 text-sm text-slate-300">{section.description}</p>
+              </div>
+              <ul className="space-y-1 text-sm text-slate-200">
+                {section.items.map((item) => (
+                  <li key={item} className="flex items-start gap-2">
+                    <span className="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-emerald-400" aria-hidden />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="flex flex-1 flex-col gap-3">
+        <h2 className="text-xl font-semibold">Third Eye Dome Dashboard</h2>
+        <iframe
+          src="https://dashboard.fiskdimension.io"
+          title="Third Eye Dome Dashboard"
+          className="h-96 w-full flex-1 rounded-xl border border-slate-800 bg-slate-900"
+          allow="fullscreen"
+        />
+      </section>
+    </div>
+  );
+}

--- a/fisk-dimension/app/council/brief/page.jsx
+++ b/fisk-dimension/app/council/brief/page.jsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ethers } from "ethers";
+import { DAO_COUNCIL_WHITELIST } from "@/lib/daoCouncil";
+
+export default function CouncilBrief() {
+  const [address, setAddress] = useState(null);
+  const [verified, setVerified] = useState(false);
+
+  const connectWallet = async () => {
+    if (!window.ethereum) {
+      alert("MetaMask required.");
+      return;
+    }
+
+    try {
+      const provider = new ethers.BrowserProvider(window.ethereum);
+      const accounts = await provider.send("eth_requestAccounts", []);
+      const signer = await provider.getSigner();
+      await signer.signMessage("Authorize DAO Council Access - Omega-9 Firestorm");
+
+      const userAddress = accounts[0];
+      setAddress(userAddress);
+
+      const isWhitelisted = DAO_COUNCIL_WHITELIST.map((wallet) => wallet.toLowerCase()).includes(
+        userAddress.toLowerCase()
+      );
+
+      setVerified(isWhitelisted);
+
+      if (!isWhitelisted) {
+        alert("⚠️ Not on DAO Council whitelist. Viewing watermarked version.");
+      }
+    } catch (error) {
+      console.error("Wallet connection failed", error);
+      alert("Connection failed. Please try again.");
+    }
+  };
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-[#0f0c29] to-[#302b63] text-white p-6">
+      <h1 className="text-3xl font-extrabold text-indigo-400 mb-6 text-center">
+        🕳 DAO COUNCIL — PRIVATE DISCLOSURE CHAMBER
+      </h1>
+
+      {!address ? (
+        <div className="flex flex-col items-center">
+          <Button onClick={connectWallet} className="bg-indigo-600 hover:bg-indigo-700">
+            Connect Wallet to Verify Access
+          </Button>
+          <p className="text-sm text-gray-400 mt-3">Encrypted access — DAO Multisig signature required.</p>
+        </div>
+      ) : (
+        <Card className="bg-black/40 border border-indigo-600 rounded-xl relative overflow-hidden">
+          {!verified && (
+            <div className="absolute inset-0 flex items-center justify-center text-center text-indigo-400 text-2xl font-bold opacity-20 pointer-events-none">
+              COUNCIL COPY – ENCRYPTED VIEW
+            </div>
+          )}
+          <CardContent className="p-4">
+            <iframe
+              src="/FISK_DIMENSION_Private_Disclosure_Brief_Template.pdf"
+              className={`w-full h-[80vh] rounded-lg border ${verified ? "border-indigo-700" : "border-red-700"}`}
+              title="Private Disclosure Brief"
+            />
+            <p className="text-xs text-gray-400 mt-2 text-center">
+              🔐 Viewing {verified ? "verified DAO council" : "restricted"} copy as: {address}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+    </main>
+  );
+}

--- a/fisk-dimension/app/disclosure/page.jsx
+++ b/fisk-dimension/app/disclosure/page.jsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export default function DisclosurePage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-black via-[#0f0c29] to-[#302b63] text-white p-6">
+      <h1 className="text-3xl font-extrabold text-emerald-400 mb-6 text-center">
+        🔱 FISK DIMENSION PUBLIC DISCLOSURE
+      </h1>
+
+      <Card className="bg-black/40 border border-emerald-500 rounded-xl mb-8">
+        <CardContent className="p-4">
+          <iframe
+            src="/FISK_DIMENSION_Public_Disclosure_Report.pdf"
+            className="w-full h-[80vh] rounded-lg border border-emerald-600"
+            title="Public Disclosure Report"
+          />
+          <div className="text-center mt-4">
+            <Button asChild className="bg-emerald-600 hover:bg-emerald-700">
+              <a href="/FISK_DIMENSION_Public_Disclosure_Report.pdf" download>
+                📥 Download Public Report
+              </a>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/fisk-dimension/components/ui/button.jsx
+++ b/fisk-dimension/components/ui/button.jsx
@@ -1,0 +1,20 @@
+import { cloneElement, isValidElement } from "react";
+import clsx from "clsx";
+
+const baseClasses =
+  "inline-flex items-center justify-center rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900";
+
+export function Button({ asChild = false, className, children, ...props }) {
+  if (asChild && isValidElement(children)) {
+    return cloneElement(children, {
+      className: clsx(baseClasses, className, children.props.className),
+      ...props
+    });
+  }
+
+  return (
+    <button className={clsx(baseClasses, className)} {...props}>
+      {children}
+    </button>
+  );
+}

--- a/fisk-dimension/components/ui/card.jsx
+++ b/fisk-dimension/components/ui/card.jsx
@@ -1,0 +1,9 @@
+import clsx from "clsx";
+
+export function Card({ className, ...props }) {
+  return <div className={clsx("rounded-xl border bg-white/5 text-white shadow", className)} {...props} />;
+}
+
+export function CardContent({ className, ...props }) {
+  return <div className={clsx("p-6", className)} {...props} />;
+}

--- a/fisk-dimension/jsconfig.json
+++ b/fisk-dimension/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/fisk-dimension/package.json
+++ b/fisk-dimension/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "fisk-dimension",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "autoprefixer": "^10.4.16",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "ethers": "^6.11.1",
+    "next": "^14.2.3",
+    "postcss": "^8.4.35",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "tailwind-merge": "^2.2.1",
+    "tailwindcss": "^3.4.3"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.3"
+  }
+}

--- a/fisk-dimension/public/FISK_DIMENSION_Private_Disclosure_Brief_Template.pdf
+++ b/fisk-dimension/public/FISK_DIMENSION_Private_Disclosure_Brief_Template.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 89 >>
+stream
+BT
+/F1 18 Tf
+72 720 Td
+(FISK Dimension Private Brief Placeholder) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000102 00000 n 
+0000000215 00000 n 
+0000000312 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+379
+%%EOF

--- a/fisk-dimension/public/FISK_DIMENSION_Public_Disclosure_Report.pdf
+++ b/fisk-dimension/public/FISK_DIMENSION_Public_Disclosure_Report.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 83 >>
+stream
+BT
+/F1 18 Tf
+72 720 Td
+(FISK Dimension Public Disclosure Placeholder) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000102 00000 n 
+0000000215 00000 n 
+0000000312 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+373
+%%EOF


### PR DESCRIPTION
## Summary
- add a fisk-dimension Next.js package with disclosure and council brief routes
- implement wallet-gated council brief page with whitelist check and watermark for restricted access
- include reusable button/card UI primitives, jsconfig aliasing, package manifest, and placeholder disclosure PDFs

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e5f609561083249af959344480a200